### PR TITLE
members & Organizers can now only see the page based on thier permision

### DIFF
--- a/client/components/Grouping/GroupList.vue
+++ b/client/components/Grouping/GroupList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useUserStore } from "@/stores/user";
 import { defineEmits, defineProps } from "vue";
 
 interface Group {
@@ -11,6 +12,7 @@ const props = defineProps<{
   groups: Group[];
 }>();
 const emit = defineEmits(["group-selected"]);
+const userStore = useUserStore();
 
 const selectGroup = (group: Group) => {
   emit("group-selected", group);
@@ -21,7 +23,13 @@ const selectGroup = (group: Group) => {
   <div class="group-list-container">
     <h2>Groups</h2>
     <div class="group-list">
-      <div v-for="group in groups" :key="group._id" class="group-item" @click="selectGroup(group)">
+      <div
+        v-for="group in groups"
+        :key="group._id"
+        class="group-item"
+        @click="selectGroup(group)"
+        :class="{ organizer: group.organizer === userStore.currentUserId, member: group.organizer !== userStore.currentUserId }"
+      >
         <span class="group-name">{{ group.name }}</span>
       </div>
     </div>
@@ -67,5 +75,16 @@ const selectGroup = (group: Group) => {
 .group-name {
   text-align: center;
   line-height: 1.2em;
+}
+
+/* Coloring based on group organizer and member  */
+.group-item.organizer {
+  background-color: #262771;
+  color: white;
+}
+
+.group-item.member {
+  background-color: #9393b8;
+  color: white;
 }
 </style>

--- a/client/components/Grouping/ManageGroup.vue
+++ b/client/components/Grouping/ManageGroup.vue
@@ -6,6 +6,7 @@ import AddMember from "./AddMembers.vue";
 
 const props = defineProps({
   group: Object,
+  role: String,
 });
 
 const emit = defineEmits(["group-updated"]);
@@ -59,7 +60,7 @@ const withdraw = async () => {
   <div class="manage-group-container">
     <h3 class="group-title">Manage Group: {{ group?.name }}</h3>
 
-    <div class="manage-section">
+    <div class="manage-section" v-if="role === 'organizer'">
       <h4>Rename Group</h4>
       <form @submit.prevent="renameGroup" class="manage-form">
         <label for="renameGroupName" class="form-label">New Group Name:</label>
@@ -77,9 +78,10 @@ const withdraw = async () => {
       </ul>
     </div>
 
-    <AddMember :groupId="group?._id" @member-added="emit('group-updated')" />
+    <!-- <AddMember :groupId="group?._id" @member-added="emit('group-updated')" /> -->
+    <AddMember v-if="role === 'organizer'" :groupId="group?._id" @member-added="emit('group-updated')" />
 
-    <div class="manage-section">
+    <div class="manage-section" v-if="role === 'organizer'">
       <h4>Contribute</h4>
       <form @submit.prevent="contribute" class="manage-form">
         <label for="contributionAmount" class="form-label">Amount:</label>
@@ -88,7 +90,7 @@ const withdraw = async () => {
       </form>
     </div>
 
-    <div class="manage-section">
+    <div class="manage-section" v-if="role === 'organizer'">
       <h4>Withdraw</h4>
       <form @submit.prevent="withdraw" class="manage-form">
         <label for="withdrawalAmount" class="form-label">Amount:</label>

--- a/client/stores/user.ts
+++ b/client/stores/user.ts
@@ -7,11 +7,13 @@ export const useUserStore = defineStore(
   "user",
   () => {
     const currentUsername = ref("");
+    const currentUserId = ref(""); // New state to store the user's ID
 
     const isLoggedIn = computed(() => currentUsername.value !== "");
 
     const resetStore = () => {
       currentUsername.value = "";
+      currentUserId.value = ""; // Reset the user ID when the store is reset
     };
 
     const createUser = async (username: string, password: string) => {
@@ -28,10 +30,12 @@ export const useUserStore = defineStore(
 
     const updateSession = async () => {
       try {
-        const { username } = await fetchy("/api/session", "GET", { alert: false });
+        const { username, _id } = await fetchy("/api/session", "GET", { alert: false });
         currentUsername.value = username;
+        currentUserId.value = _id; // Update the current user ID from the session data
       } catch {
         currentUsername.value = "";
+        currentUserId.value = ""; // Reset the user ID if session update fails
       }
     };
 
@@ -76,6 +80,7 @@ export const useUserStore = defineStore(
 
     return {
       currentUsername,
+      currentUserId, // Expose the new state
       isLoggedIn,
       createUser,
       loginUser,

--- a/client/views/GroupView.vue
+++ b/client/views/GroupView.vue
@@ -17,7 +17,7 @@ interface Group {
 const groups = ref<Group[]>([]);
 const selectedGroup = ref<Group | null>(null);
 const userStore = useUserStore();
-const userRole = ref<string | null>(null);
+const userRole = ref<string | undefined>(undefined);
 
 const fetchGroups = async () => {
   try {


### PR DESCRIPTION
Here are the changes made in this repo:
1. Now, only members and organizers can see the list of groups that they are affiliated with. 
2. The organizer and member groups are color-coded according to our Figma design. 
If the user is an organizer of the group, the group will show them a darker blue color, and if they are only members, they will see a lighter color.

3. Only the organizer has access to an editable section of the page. Members are restricted from accessing these pages. 

Note: Further improvements will be implemented as we conclude the remaining concepts !!
 
 
